### PR TITLE
fix(infrustructure-step): Fix quality gate selects not pre-filling

### DIFF
--- a/frontend/skelify/src/app/components/infrastructure-step/infrastructure-step.html
+++ b/frontend/skelify/src/app/components/infrastructure-step/infrastructure-step.html
@@ -220,18 +220,10 @@
             <label for="quality-gate-fe" class="form-label">Quality Gate FE</label>
             <select id="quality-gate-fe" class="form-input"
                     [value]="wizardState.infrastructure().sonarQube.qualityGateFE"
-                    (input)="onQualityGateFEChange($event)">
-              <option [value]="qualityOptions[0]">{{ qualityOptions[0] }}</option>
-              <option [value]="qualityOptions[1]">{{ qualityOptions[1] }}</option>
-              <option [value]="qualityOptions[2]">{{ qualityOptions[2] }}</option>
-              <option [value]="qualityOptions[3]">{{ qualityOptions[3] }}</option>
-              <option [value]="qualityOptions[4]">{{ qualityOptions[4] }}</option>
-              <option [value]="qualityOptions[5]">{{ qualityOptions[5] }}</option>
-              <option [value]="qualityOptions[6]">{{ qualityOptions[6] }}</option>
-              <option [value]="qualityOptions[7]">{{ qualityOptions[7] }}</option>
-              <option [value]="qualityOptions[8]">{{ qualityOptions[8] }}</option>
-              <option [value]="qualityOptions[9]">{{ qualityOptions[9] }}</option>
-              <option [value]="qualityOptions[10]">{{ qualityOptions[10] }}</option>
+                    (change)="onQualityGateFEChange($event)">
+              @for (option of qualityOptions; track option) {
+                <option [value]="option">{{ option }}</option>
+              }
             </select>
           </div>
 
@@ -248,18 +240,10 @@
             <label for="quality-gate-be" class="form-label">Quality Gate BE</label>
             <select id="quality-gate-be" class="form-input"
                     [value]="wizardState.infrastructure().sonarQube.qualityGateBE"
-                    (input)="onQualityGateBEChange($event)">
-              <option [value]="qualityOptions[0]">{{ qualityOptions[0] }}</option>
-              <option [value]="qualityOptions[1]">{{ qualityOptions[1] }}</option>
-              <option [value]="qualityOptions[2]">{{ qualityOptions[2] }}</option>
-              <option [value]="qualityOptions[3]">{{ qualityOptions[3] }}</option>
-              <option [value]="qualityOptions[4]">{{ qualityOptions[4] }}</option>
-              <option [value]="qualityOptions[5]">{{ qualityOptions[5] }}</option>
-              <option [value]="qualityOptions[6]">{{ qualityOptions[6] }}</option>
-              <option [value]="qualityOptions[7]">{{ qualityOptions[7] }}</option>
-              <option [value]="qualityOptions[8]">{{ qualityOptions[8] }}</option>
-              <option [value]="qualityOptions[9]">{{ qualityOptions[9] }}</option>
-              <option [value]="qualityOptions[10]">{{ qualityOptions[10] }}</option>
+                    (change)="onQualityGateBEChange($event)">
+              @for (option of qualityOptions; track option) {
+                <option [value]="option">{{ option }}</option>
+              }
             </select>
           </div>
 

--- a/frontend/skelify/src/app/components/infrastructure-step/infrastructure-step.ts
+++ b/frontend/skelify/src/app/components/infrastructure-step/infrastructure-step.ts
@@ -40,8 +40,6 @@ export class InfrastructureStep implements OnInit{
 
   projectInfo = this.wizardState.projectInfo();
 
-  qualityGateFE = computed(() => this.wizardState.infrastructure().sonarQube.qualityGateFE);
-  qualityGateBE = computed(() => this.wizardState.infrastructure().sonarQube.qualityGateBE);
   sonarNameFE = computed(() => `${AppConstants.WIZARD.PREFIX_SONAR}${this.projectInfo.packageName}.fe`);
   sonarNameBE = computed(() => `${AppConstants.WIZARD.PREFIX_SONAR}${this.projectInfo.packageName}.be`);
   deploymentDevNamespace = computed(() =>`${AppConstants.WIZARD.PREFIX_DEPLOYMENT}${this.wizardState.projectInfo().projectName}-dev`);
@@ -108,12 +106,12 @@ export class InfrastructureStep implements OnInit{
   }
 
   onQualityGateFEChange(event: Event) {
-    const target = event.target as HTMLInputElement;
+    const target = event.target as HTMLSelectElement;
     this.wizardState.updateSonarQube({ qualityGateFE: target.value });
   }
 
   onQualityGateBEChange(event: Event) {
-    const target = event.target as HTMLInputElement;
+    const target = event.target as HTMLSelectElement;
     this.wizardState.updateSonarQube({ qualityGateBE: target.value });
   }
 


### PR DESCRIPTION
The quality gate select fields for FE and BE in the infrastructure step were not being pre-filled with the values from the wizard state.

This was because the `<option>` elements were hardcoded in the HTML template, instead of being dynamically generated from the `qualityOptions` array.

This commit replaces the hardcoded options with an `@for` loop to correctly render the select options and ensure the values are pre-filled. The event handlers have also been corrected to use the proper `HTMLSelectElement` type.