### PR TITLE
Add Domain Tab to Wizard

### DIFF
--- a/frontend/skelify/package-lock.json
+++ b/frontend/skelify/package-lock.json
@@ -12923,18 +12923,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint": {
       "version": "9.36.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",

--- a/frontend/skelify/src/app/components/domain-step/domain-step.html
+++ b/frontend/skelify/src/app/components/domain-step/domain-step.html
@@ -1,0 +1,35 @@
+<div class="domain-step-container p-6">
+  <h2 class="text-2xl font-bold mb-4">Domain Configuration</h2>
+
+  <form [formGroup]="domainForm">
+    <div formArrayName="entities">
+      <div *ngFor="let entity of entities.controls; let i = index" [formGroupName]="i" class="mb-6 p-4 border rounded-lg">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-semibold">Entity: {{ entity.get('name')?.value || 'New Entity' }}</h3>
+          <button (click)="removeEntity(i)" type="button" class="text-red-500 hover:text-red-700">Remove Entity</button>
+        </div>
+
+        <div class="mb-4">
+          <label class="block text-sm font-medium text-gray-700">Entity Name</label>
+          <input type="text" formControlName="name" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+        </div>
+
+        <h4 class="text-lg font-medium mb-2">Columns</h4>
+        <div formArrayName="columns">
+          <div *ngFor="let column of getColumns(entity).controls; let j = index" [formGroupName]="j" class="grid grid-cols-4 gap-4 items-center mb-2">
+            <input type="text" formControlName="name" placeholder="Column Name" class="col-span-1 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+            <input type="text" formControlName="type" placeholder="Column Type" class="col-span-1 mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+            <div class="col-span-1 flex items-center">
+              <input type="checkbox" formControlName="required" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+              <label class="ml-2 block text-sm text-gray-900">Required</label>
+            </div>
+            <button (click)="removeColumn(i, j)" type="button" class="col-span-1 text-red-500 hover:text-red-700 justify-self-end">Remove Column</button>
+          </div>
+        </div>
+        <button (click)="addColumn(i)" type="button" class="mt-2 text-indigo-600 hover:text-indigo-800">Add Column</button>
+      </div>
+    </div>
+  </form>
+
+  <button (click)="addEntity()" type="button" class="mt-4 text-indigo-600 hover:text-indigo-800">Add Entity</button>
+</div>

--- a/frontend/skelify/src/app/components/domain-step/domain-step.scss
+++ b/frontend/skelify/src/app/components/domain-step/domain-step.scss
@@ -1,0 +1,1 @@
+/* Add any specific styles for the domain step here */

--- a/frontend/skelify/src/app/components/domain-step/domain-step.ts
+++ b/frontend/skelify/src/app/components/domain-step/domain-step.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { FormBuilder, FormGroup, FormArray, Validators, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { WizardStateService } from '../../services/wizard-state';
+import { Domain, Entity } from '../../models/page/wizard-state.model';
+
+@Component({
+  selector: 'app-domain-step',
+  templateUrl: './domain-step.html',
+  styleUrls: ['./domain-step.scss'],
+  imports: [CommonModule, ReactiveFormsModule],
+  standalone: true,
+})
+export class DomainStepComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly wizardState = inject(WizardStateService);
+
+  domainForm: FormGroup = this.fb.group({
+    entities: this.fb.array([]),
+  });
+
+  ngOnInit() {
+    const currentDomain = this.wizardState.domain();
+    if (currentDomain && currentDomain.entities) {
+      currentDomain.entities.forEach(entity => {
+        this.addEntity(entity);
+      });
+    }
+
+    this.domainForm.valueChanges.subscribe((value: Domain) => {
+      this.wizardState.updateDomain(value);
+    });
+  }
+
+  get entities(): FormArray {
+    return this.domainForm.get('entities') as FormArray;
+  }
+
+  addEntity(entity?: Entity) {
+    const entityGroup = this.fb.group({
+      name: [entity ? entity.name : '', Validators.required],
+      columns: this.fb.array([]),
+    });
+
+    if (entity && entity.columns) {
+      entity.columns.forEach(column => {
+        (entityGroup.get('columns') as FormArray).push(this.fb.group({
+          name: [column.name, Validators.required],
+          type: [column.type, Validators.required],
+          required: [column.required],
+        }));
+      });
+    }
+
+    this.entities.push(entityGroup);
+  }
+
+  removeEntity(index: number) {
+    this.entities.removeAt(index);
+  }
+
+  getColumns(entity: any): FormArray {
+    return entity.get('columns') as FormArray;
+  }
+
+  addColumn(entityIndex: number) {
+    const columns = this.getColumns(this.entities.at(entityIndex));
+    columns.push(this.fb.group({
+      name: ['', Validators.required],
+      type: ['', Validators.required],
+      required: [false],
+    }));
+  }
+
+  removeColumn(entityIndex: number, columnIndex: number) {
+    const columns = this.getColumns(this.entities.at(entityIndex));
+    columns.removeAt(columnIndex);
+  }
+}

--- a/frontend/skelify/src/app/models/page/wizard-state.model.ts
+++ b/frontend/skelify/src/app/models/page/wizard-state.model.ts
@@ -11,9 +11,25 @@ export interface DeploymentEnv {
   namespace: string;
 }
 
+export interface Column {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+export interface Entity {
+  name: string;
+  columns: Column[];
+}
+
+export interface Domain {
+  entities: Entity[];
+}
+
 export interface WizardStateModel {
   currentStep: number;
   currentSubstep: number;
+  domain: Domain;
   projectInfo: {
     projectName: string;
     projectDescription: string;

--- a/frontend/skelify/src/app/pages/wizard-page/wizard-page.html
+++ b/frontend/skelify/src/app/pages/wizard-page/wizard-page.html
@@ -8,12 +8,15 @@
         <app-project-info-step (isFormValid)="isProjectInfoFormValid.set($event)" />
       }
       @case (2) {
-        <app-tech-stack-step />
+        <app-domain-step />
       }
       @case (3) {
-        <app-infrastructure-step />
+        <app-tech-stack-step />
       }
       @case (4) {
+        <app-infrastructure-step />
+      }
+      @case (5) {
         <app-review-step />
       }
     }

--- a/frontend/skelify/src/app/pages/wizard-page/wizard-page.ts
+++ b/frontend/skelify/src/app/pages/wizard-page/wizard-page.ts
@@ -6,6 +6,7 @@ import { ProjectInfoStep } from '../../components/project-info-step/project-info
 import { TechStackStep } from '../../components/tech-stack-step/tech-stack-step';
 import { InfrastructureStep } from '../../components/infrastructure-step/infrastructure-step';
 import { ReviewStep } from '../../components/review-step/review-step';
+import { DomainStepComponent } from '../../components/domain-step/domain-step';
 
 @Component({
   selector: 'app-wizard-page',
@@ -15,6 +16,7 @@ import { ReviewStep } from '../../components/review-step/review-step';
     CommonModule,
     ProgressBar,
     ProjectInfoStep,
+    DomainStepComponent,
     TechStackStep,
     InfrastructureStep,
     ReviewStep

--- a/frontend/skelify/src/app/services/wizard-state.ts
+++ b/frontend/skelify/src/app/services/wizard-state.ts
@@ -1,5 +1,5 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
-import { Person, PipelineStep, WizardStateModel } from "../models/page/wizard-state.model";
+import {Domain, Person, PipelineStep, WizardStateModel} from "../models/page/wizard-state.model";
 import { AppConstants } from "../models/constant/app-constant";
 import { GenerationService } from './generation.service';
 import { finalize } from 'rxjs';
@@ -12,6 +12,7 @@ export class WizardStateService {
   private readonly state = signal(this.initialState);
   readonly steps = signal([
     { label: 'Project Info' },
+    { label: 'Domain' },
     { label: 'Tech Stack' },
     { label: 'Infrastructure' },
     { label: 'Review' }
@@ -31,11 +32,12 @@ export class WizardStateService {
   readonly currentStep = computed(() => this.state().currentStep);
   readonly currentSubstep = computed(() => this.state().currentSubstep);
   readonly projectInfo = computed(() => this.state().projectInfo);
+  readonly domain = computed(() => this.state().domain);
   readonly techStack = computed(() => this.state().techStack);
   readonly infrastructure = computed(() => this.state().infrastructure);
   readonly isLastStep = computed(() => this.currentStep() === this.steps().length);
 
-  readonly isPipelineStep = computed(() => this.currentStep() === 3);
+  readonly isPipelineStep = computed(() => this.currentStep() === 4);
   readonly isLastPipelineStep = computed(() => this.currentSubstep() === this.pipelineSteps().length);
 
   get initialState(): WizardStateModel {
@@ -89,6 +91,10 @@ export class WizardStateService {
 
   updateProjectInfo(projectInfo: Partial<WizardStateModel['projectInfo']>) {
     this.state.update(state => ({ ...state, projectInfo: { ...state.projectInfo, ...projectInfo } }));
+  }
+
+  updateDomain(domain: Partial<Domain>) {
+    this.state.update(state => ({ ...state, domain: { ...state.domain, ...domain } }));
   }
 
   updateTechStack(techStack: Partial<WizardStateModel['techStack']>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This commit introduces a new 'Domain' tab to the wizard, positioned as the second step. The new tab allows users to define a list of entities and, for each entity, a list of columns with a name, type, and a 'required' flag.

Key changes include:
- A new `DomainStepComponent` with a reactive form for managing entities and columns.
- Updated `WizardStateService` to handle the domain data.
- Integration of the new component into the main wizard flow.